### PR TITLE
Add Arduino Nano ESP32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # TMC_2209_ESP32 and Micropython
-This is a libary to drive a stepper motor with a TMC2209 stepper driver and a LOLIN32 V1.0.0 ESP32 Board
+This is a library to drive a stepper motor with a TMC2209 stepper driver and a LOLIN32 V1.0.0 ESP32 Board.
+The code has been tested with MicroPython and should also run on the Arduino
+Nano ESP32 when flashed with the MicroPython firmware.  In that case you may
+need to adapt the UART pins used to communicate with the driver (see
+``TMC_2209`` constructor).
 
 This is a clone off the great work from Chr157i4n, thank you for the time you spend !
 https://github.com/Chr157i4n/TMC2209_Raspberry_Pi

--- a/tmc/TMC_2209_StepperDriver.py
+++ b/tmc/TMC_2209_StepperDriver.py
@@ -74,9 +74,17 @@ class TMC_2209:
 #-----------------------------------------------------------------------
 # constructor
 #-----------------------------------------------------------------------
-    def __init__(self, pin_step, pin_dir, pin_en, baudrate=115200, serialport=2):
-        
-        self.tmc_uart = TMC_UART(serialport, baudrate)
+    def __init__(self, pin_step, pin_dir, pin_en, baudrate=115200, serialport=2,
+                 tx=16, rx=17):
+
+        """Create a new ``TMC_2209`` instance.
+
+        ``tx`` and ``rx`` specify the UART pins used to communicate with the
+        driver.  Override them if the defaults (16/17) do not match your
+        board's layout, e.g. on the Arduino Nano ESP32.
+        """
+
+        self.tmc_uart = TMC_UART(serialport, baudrate, tx=tx, rx=rx)
         self._pin_step = pin_step
         self._pin_dir = pin_dir
         self._pin_en = pin_en
@@ -102,7 +110,9 @@ class TMC_2209:
         if(self._loglevel >= Loglevel.info):
             print("TMC2209: Deinit")
         self.setMotorEnabled(False)
-        GPIO.cleanup() 
+        # ``machine.Pin`` does not provide a cleanup method as found on
+        # Raspberry Pi GPIO libraries. The pins simply remain configured as
+        # they were, so nothing needs to be done here.
 
 #-----------------------------------------------------------------------
 # set the loglevel. See the Enum Loglevel

--- a/tmc/TMC_2209_uart.py
+++ b/tmc/TMC_2209_uart.py
@@ -25,10 +25,17 @@ class TMC_UART:
 #-----------------------------------------------------------------------
 # constructor
 #-----------------------------------------------------------------------
-    def __init__(self, serialport, baudrate):
-        self.ser = UART(serialport, baudrate=115200, tx=16, rx=17) 
+    def __init__(self, serialport, baudrate, tx=16, rx=17):
+        """Initialize UART communication.
+
+        The ``tx`` and ``rx`` pins can be adapted for different boards.  The
+        defaults (16/17) match many ESP32 development boards but the Arduino
+        Nano ESP32 exposes different pins for UART.  Pass the correct pins when
+        creating the class if required.
+        """
+        self.ser = UART(serialport, baudrate=baudrate, tx=tx, rx=rx)
         self.mtr_id=0
-        self.ser.init(115200 , bits=8, parity=None, stop=1)
+        self.ser.init(baudrate , bits=8, parity=None, stop=1)
         #self.ser.timeout = 20000/baudrate            # adjust per baud and hardware. Sequential reads without some delay fail.
         self.communication_pause = 500/baudrate     # adjust per baud and hardware. Sequential reads without some delay fail.
 
@@ -39,7 +46,15 @@ class TMC_UART:
 # destructor
 #-----------------------------------------------------------------------
     def __del__(self):
-        self.ser.close()
+        """De-initialise the UART on garbage collection."""
+        try:
+            self.ser.deinit()
+        except AttributeError:
+            # ``deinit`` is the MicroPython API. Fallback in case ``close`` exists
+            try:
+                self.ser.close()
+            except AttributeError:
+                pass
 
 #-----------------------------------------------------------------------
 # this function calculates the crc8 parity bit


### PR DESCRIPTION
## Summary
- allow specifying UART TX/RX pins when creating `TMC_2209` and `TMC_UART`
- clean up deinitialisation for MicroPython
- document Nano ESP32 usage in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`